### PR TITLE
Declarative duts_config and DUT collection refactor

### DIFF
--- a/common.py
+++ b/common.py
@@ -38,9 +38,13 @@ class ConfigFile:
 
     def load(self):
         with meta_lock:
-            self.__access()
             with open(self.path, 'r') as conf:
-                return yaml.safe_load(conf)
+                # config can be None if file is being overwritten at read time
+                # don't update last modify time - let the file be re-read
+                config = yaml.safe_load(conf)
+                if config:
+                    self.__access()
+                return config
 
     def save(self, data):
         with meta_lock:

--- a/common.py
+++ b/common.py
@@ -29,7 +29,12 @@ class ConfigFile:
         self.last_modify = os.path.getmtime(self.path)
 
     def need_reload(self):
-        return self.last_modify != os.path.getmtime(self.path)
+        try:
+            return self.last_modify != os.path.getmtime(self.path)
+        except FileNotFoundError:
+            # can occur on config file overwrite
+            self.last_modify = 0
+            raise
 
     def load(self):
         with meta_lock:

--- a/common.py
+++ b/common.py
@@ -1,5 +1,7 @@
 #
 # Copyright(c) 2023 Intel Corporation
+# Copyright(c) 2024 Huawei Technologies
+# Copyright(c) 2026 Unvertical
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
@@ -10,9 +12,7 @@ from json.decoder import JSONDecodeError
 import hashlib
 import json
 import os
-import random
 import re
-import sys
 import time
 import yaml
 
@@ -173,7 +173,7 @@ class TestEvent(dict):
             start_time = self['start-timestamp']
             end_time = self.get('end-timestamp', time.time())
             return timedelta(seconds=int(end_time-start_time))
-        except:
+        except KeyError:
             return timedelta(0)
 
     def __eq__(self, other):
@@ -195,6 +195,7 @@ class TestEvent(dict):
             },
             **data
         })
+
 
 class JournalParser:
     def __init__(self, journal_file):

--- a/jogger
+++ b/jogger
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 #
 # Copyright(c) 2023 Intel Corporation
+# Copyright(c) 2024 Huawei Technologies
 # Copyright(c) 2026 Unvertical
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-from common import ConfigFile, JournalFile, StatusFile, TestCase, TestEvent, JournalParser
+from common import JournalFile, StatusFile, TestCase, TestEvent, JournalParser
 
 from datetime import datetime
 from functools import reduce
@@ -13,7 +14,6 @@ from tabulate import tabulate
 from tempfile import NamedTemporaryFile
 import argparse
 import daemon
-import hashlib
 import json
 import os
 import shutil
@@ -28,19 +28,19 @@ def error(*args, **kwargs):
 class Printer:
     @staticmethod
     def red(string):
-        return "\033[0;31m"+string+"\033[0m"
+        return "\033[0;31m" + string + "\033[0m"
 
     @staticmethod
     def green(string):
-        return "\033[0;32m"+string+"\033[0m"
+        return "\033[0;32m" + string + "\033[0m"
 
     @staticmethod
     def yellow(string):
-        return "\033[0;33m"+string+"\033[0m"
+        return "\033[0;33m" + string + "\033[0m"
 
     @staticmethod
     def blue(string):
-        return "\033[0;34m"+string+"\033[0m"
+        return "\033[0;34m" + string + "\033[0m"
 
 
 class DataPrinter:
@@ -48,7 +48,7 @@ class DataPrinter:
         if output_format not in ['table', 'json']:
             raise ValueError(f"Invalid output format '{output_format}'")
         self.output_format = output_format
-        self.caption = None
+        self.captions = None
         self.data = None
 
     def setCaptions(self, captions):
@@ -189,7 +189,7 @@ class ScopeHandler:
         )
 
     def run(self, req):
-        tests = reduce(lambda acc, sha: acc+self.__tests_by_sha(sha), req, [])
+        tests = reduce(lambda acc, sha: acc + self.__tests_by_sha(sha), req, [])
         test_events = []
         with self.journal_file.record() as journal:
             for test_case in tests:
@@ -225,7 +225,7 @@ class ScopeHandler:
                 result_event = results_dict[test_event['sha']]
                 del result_event['status']
                 test_event.update(result_event)
-            except:
+            except (KeyError, TypeError):
                 test_event['status'] = "error"
 
         return queue
@@ -239,7 +239,6 @@ class ScopeHandler:
         for res in results:
             results_dict[res['sha']] = res
 
-        scope_status = []
         for test_case in tests:
             queued_events = filter(
                 lambda e: e['test-case'] == test_case,
@@ -304,7 +303,6 @@ class ScopeHandler:
         )
 
 
-
 class TestSelector:
     def __init__(self, tests):
         self.tests = tests
@@ -325,6 +323,7 @@ class TestSelector:
 
             tmpf.seek(0)
             return [line.split()[0] for line in tmpf.readlines()]
+
 
 usage = """%(prog)s command [args]
 
@@ -356,13 +355,15 @@ class SuperRunnerCli:
         self.scope_handler = ScopeHandler()
         getattr(self, command)(f"{parser.prog} {args.command}", argv[1:])
 
-    def __color_result(self, string):
+    @staticmethod
+    def __color_result(string):
         return {
             'PASSED': Printer.green,
             'FAILED': Printer.red,
         }.get(string, Printer.yellow)(string)
 
-    def __print_test_events(self, args, test_events):
+    @staticmethod
+    def __print_test_events(args, test_events):
         p = ListPrinter(args.format)
         id_field = ('id', 'sha')[args.long]
         test_field = ('function', 'test')[args.long]
@@ -384,16 +385,17 @@ class SuperRunnerCli:
             })
         p.print()
 
-    def init(self, prog, argv):
+    @staticmethod
+    def init(prog, argv):
         parser = argparse.ArgumentParser(
             prog=prog,
             description="Initialize new test scope"
         )
-        args = parser.parse_args(argv)
+        _ = parser.parse_args(argv)
 
         runner_path = os.getenv('RUNNER_PATH')
         if not runner_path:
-            error("Enrvironment variable 'RUNNER_PATH' is not set!")
+            error("Environment variable 'RUNNER_PATH' is not set!")
             exit(1)
         if os.path.isdir("meta"):
             error("Existing runner scope found in this directory!")
@@ -427,7 +429,7 @@ class SuperRunnerCli:
                 'sha': test_case['sha'],
                 'function': test_case.function(),
                 'test': test_case.test()
-        })
+            })
         p.print()
 
     def run(self, prog, argv):
@@ -488,7 +490,7 @@ class SuperRunnerCli:
         args = parser.parse_args(argv)
 
         test_event = self.scope_handler.test_event_by_sha({'sha': args.id})
-        deleted_event = self.scope_handler.delete({'test-event': test_event})
+        self.scope_handler.delete({'test-event': test_event})
 
     def queue(self, prog, argv):
         parser = argparse.ArgumentParser(
@@ -557,9 +559,9 @@ class SuperRunnerCli:
                 last_event_result = self.__color_result(last_event['result'])
                 last_event_id = last_event['sha'][:16]
                 last_event_sha = last_event['sha']
-                last_event_date = datetime.fromtimestamp(last_event['end-timestamp']) \
-                                          .strftime("%Y-%m-%d %H:%M:%S")
-            except:
+                last_event_date = (datetime.fromtimestamp(last_event['end-timestamp'])
+                                   .strftime("%Y-%m-%d %H:%M:%S"))
+            except (KeyError, TypeError):
                 last_event_result = last_event_id = last_event_sha = last_event_date = ""
             p.addEntry({
                 'id': test_case['sha'][:16],
@@ -572,7 +574,7 @@ class SuperRunnerCli:
                 'last-result-id': last_event_id,
                 'last-result-sha': last_event_sha,
                 'last-result-date': last_event_date
-        })
+            })
         p.print()
 
     def results(self, prog, argv):
@@ -621,7 +623,7 @@ class SuperRunnerCli:
                 'test': test_case.test(),
                 'result': self.__color_result(test_event['result']),
                 'duration': test_event.duration()
-        })
+            })
         p.print()
 
     def show(self, prog, argv):
@@ -702,7 +704,8 @@ class SuperRunnerCli:
             with daemon.DaemonContext():
                 webbrowser.open_new_tab(os.path.join(test_case['logs'], "main.html"))
 
-    def stdout(self, prog, argv):
+    @staticmethod
+    def stdout(prog, argv):
         parser = argparse.ArgumentParser(
             prog=prog,
             description="Show pytest standard output on selected DUT"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-daemon>=2.2.4
 setproctitle>=1.1.10
 tabulate>=0.8.7
 watchdog>=0.10.3
+pyyaml>=5.4

--- a/runnerd
+++ b/runnerd
@@ -141,33 +141,27 @@ class DutsManager:
                 del self.duts[host]
         for config in self.duts_config['duts']:
             host = config["host"]
-            if host in self.duts:
-                # update config for existing dut
-                self.duts[host].config = {**self.base_dut_config, **config}
-            else:
-                # add dut
-                dut = Dut({**self.base_dut_config, **config})
-                self.duts[config["host"]] = dut
-                self.mark_free(dut)
+            add_dut = host not in self.duts
+            self.duts[host] = Dut({**self.base_dut_config, **config})
+            if add_dut:
+                self.mark_free(self.duts[host])
 
-    def get_free_dut(self, dut_filter=None):
-        filtered_duts = []
+    def get_free_dut(self):
         dut = None
         for _ in self.duts:
             free_dut = self.duts_queue.get()
-            if not dut_filter or dut_filter(free_dut):
+            if free_dut.host in self.duts:
                 dut = free_dut
                 break
-            if free_dut.host in self.duts:
-                filtered_duts.append(free_dut)
-        map(self.mark_free, filtered_duts)
         if not dut:
-            raise Exception("No DUT matching to filter!")
+            raise LookupError()
         return dut
 
     def mark_free(self, dut):
+        # DUTs can be removed from list or updated during test execution
+        # do not re-queue removed DUT or queue DUT by IP to get current DUT entry
         if dut.host in self.duts:
-            self.duts_queue.put(dut)
+            self.duts_queue.put(self.duts[dut.host])
 
 
 class TestManager:
@@ -289,7 +283,11 @@ class MasterRunner:
         while True:
             self.duts_manager.collect_duts()
             log.debug("Looking for free DUT... ")
-            dut = self.duts_manager.get_free_dut()
+            try:
+                dut = self.duts_manager.get_free_dut()
+            except LookupError:
+                log.debug("No available DUTs found!")
+                continue
             log.debug(f"Found DUT {dut.host}")
             log.debug("Looking for next test... ")
             test_event = self.test_manager.get_next_test()
@@ -366,7 +364,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--debug', action='store_true')
     parser.add_argument('--no-daemon', action='store_true')
-    parser.add_argument('--version', action='version', version='Superrunner4000 v0.2')
+    parser.add_argument('--version', action='version', version='Superrunner4000 v0.3')
     args = parser.parse_args()
 
     log.setLevel((logging.INFO, logging.DEBUG)[args.debug])

--- a/runnerd
+++ b/runnerd
@@ -134,9 +134,15 @@ class DutsManager:
 
     def collect_duts(self):
         with self.lock:
-            if not self.duts_config_file.need_reload():
-                return
-
+            while True:
+                try:
+                    if not self.duts_config_file.need_reload():
+                        return
+                    else:
+                        break
+                except FileNotFoundError:
+                    pass
+            log.info("Reloading DUTs config...")
             self.duts_config = self.duts_config_file.load()
             configured_duts = self.duts_config.get('duts', [])
             if configured_duts is None:
@@ -161,7 +167,7 @@ class DutsManager:
 
     def get_free_dut(self):
         dut = None
-        for _ in self.duts:
+        while self.duts_queue.qsize():
             free_dut = self.duts_queue.get()
             if free_dut.host in self.duts:
                 dut = free_dut
@@ -288,6 +294,8 @@ class MasterRunner:
 
     def run(self):
         def test_run_complete(dut, test_event):
+            # Sometimes mark_free is quicker than reaching collect_duts in the loop below what
+            # results in queuing next test on removed DUT. collect_duts here prevents that.
             self.duts_manager.collect_duts()
             self.duts_manager.mark_free(dut)
             test_event['end-timestamp'] = time.time()
@@ -296,16 +304,16 @@ class MasterRunner:
 
         while True:
             self.duts_manager.collect_duts()
-            if not self.duts_manager.duts:
+            if not self.duts_manager.duts_queue.qsize():
                 continue
-            log.debug("Looking for free DUT... ")
+            log.debug("Looking for a free DUT... ")
             try:
                 dut = self.duts_manager.get_free_dut()
             except LookupError:
                 log.warning("No available DUTs found!")
                 continue
             log.debug(f"Found DUT {dut.host}")
-            log.debug("Looking for next test... ")
+            log.debug("Looking for the next test... ")
             test_event = self.test_manager.get_next_test()
             log.debug(f"Found test {test_event}")
             test_event['host'] = dut.host

--- a/runnerd
+++ b/runnerd
@@ -9,7 +9,7 @@
 from common import ConfigFile, JournalFile, StatusFile, TestCase, TestEvent, JournalParser
 
 from pathlib import Path
-from queue import Queue
+from queue import Queue, Empty
 from setproctitle import setproctitle
 from subprocess import Popen, PIPE
 from tempfile import NamedTemporaryFile
@@ -125,12 +125,13 @@ class DutsManager:
     base_dut_config_path = "configs/base_dut_config.yml"
 
     def __init__(self, duts_config_file):
-        self.dut_dict_lock = Lock()
+        self.duts_lock = Lock()
         self.duts_config = None
         self.duts_config_file = duts_config_file
         self.base_dut_config = ConfigFile(self.base_dut_config_path).load()
-        self.duts_queue = Queue()
+        self.duts_queue = DutQueue()
         self.duts = {}
+        self.duts_in_use = set()
 
     def collect_duts(self):
         start_time = time.time()
@@ -146,41 +147,73 @@ class DutsManager:
                     start_time = time.time()
                 time.sleep(0.5)
 
-        with self.dut_dict_lock:
-            log.info("Reloading DUTs config...")
+        with self.duts_lock:
+            log.debug("Reloading DUTs config...")
             self.duts_config = self.duts_config_file.load()
-            configured_duts = self.duts_config.get('duts', [])
-            if configured_duts is None:
-                log.warning("Incorrect DUTs config!")
+            if self.duts_config is None:
+                log.error("Error while loading DUTs config!")
                 return
-            host_list = [dut["host"] for dut in self.duts_config["duts"]]
+            configured_duts = self.duts_config.get('duts', [])
+            if not configured_duts:
+                log.warning("DUT list is empty!")
+                return
+            host_list = [dut["host"] for dut in configured_duts]
             for host in self.duts.copy():
                 # remove duts deleted from duts_config_file
                 if host not in host_list:
-                    log.debug(f"Removing DUT {host} from scope")
+                    log.info(f"Removing DUT {host} from scope (currently running test "
+                             "will NOT be terminated)")
                     del self.duts[host]
-            if host_list:
-                for config in self.duts_config['duts']:
-                    host = config["host"]
-                    add_dut = host not in self.duts
-                    self.duts[host] = Dut({**self.base_dut_config, **config})
-                    if add_dut:
-                        log.debug(f"Adding DUT {host} to scope")
-                        self.mark_free(self.duts[host])
-            else:
-                log.warning("DUT list is empty!")
+            for config in configured_duts:
+                host = config["host"]
+                merged_config = {**self.base_dut_config, **config}
+                add_dut = host not in self.duts
+                if add_dut or self.duts[host].config != merged_config:
+                    self.duts[host] = Dut(merged_config)
+                if add_dut:
+                    log.info(f"Adding DUT {host} to scope")
+                    if host not in self.duts_in_use:
+                        self.duts_queue.put(self.duts[host])
+                    else:
+                        log.debug(f"DUT {host} is already in use - skip adding to queue")
+            log.debug("DUTs config reloaded")
 
     def get_free_dut(self):
-        free_dut = self.duts_queue.get()
-        if free_dut.host in self.duts:
-            return free_dut
+        with self.duts_lock:
+            while True:
+                # raise Empty if queue is empty
+                dut = self.duts_queue.get(block=False)
+                if dut.host in self.duts:
+                    self.duts_in_use.add(dut.host)
+                    return dut
 
     def mark_free(self, dut):
-        with self.dut_dict_lock:
-            # DUTs can be removed from list or updated during test execution
-            # do not re-queue removed DUT or queue DUT by IP to get current DUT entry
+        with self.duts_lock:
+            self.duts_in_use.remove(dut.host)
+            # re-queue only currently configured DUTs
             if dut.host in self.duts:
+                # use current DUT entry (might be updated in the meantime)
                 self.duts_queue.put(self.duts[dut.host])
+
+
+class DutQueue(Queue):
+    """Queue with unique DUT entries"""
+    def __init__(self):
+        super().__init__()
+        self.dut_set = set()
+        self.set_lock = Lock()
+
+    def put(self, dut: Dut, block=True, timeout=None):
+        with self.set_lock:
+            if dut.host not in self.dut_set:
+                self.dut_set.add(dut.host)
+                super().put(dut, block, timeout)
+
+    def get(self, block=True, timeout=None) -> Dut:
+        with self.set_lock:
+            dut = super().get(block, timeout)
+            self.dut_set.remove(dut.host)
+            return dut
 
 
 class TestManager:
@@ -303,14 +336,14 @@ class MasterRunner:
             self.duts_manager.collect_duts()
             if not self.duts_manager.duts_queue.qsize():
                 continue
-            log.debug("Looking for a free DUT... ")
+            log.debug("Looking for a free DUT...")
             try:
                 dut = self.duts_manager.get_free_dut()
-            except LookupError:
-                log.warning("No available DUTs found!")
+            except Empty:
+                log.debug("No free DUTs at the moment! Waiting...")
                 continue
             log.debug(f"Found DUT {dut.host}")
-            log.debug("Looking for the next test... ")
+            log.debug("Looking for the next test...")
             test_event = self.test_manager.get_next_test()
             log.debug(f"Found test {test_event}")
             test_event['host'] = dut.host
@@ -328,7 +361,7 @@ class ScopeParser:
         self.scope_file = StatusFile("meta/scope.json")
 
     def __parse_config(self):
-        log.debug("Reloading scope config")
+        log.debug("Reloading scope config...")
         scope_config = self.scope_config_file.load()
         scope = self.scope_file.load()
         pytest_runner = PytestRunner(test_dir=scope_config['tests_path'])
@@ -353,6 +386,7 @@ class ScopeParser:
                     pytest_options
                 ))
         test_cases = list(dict.fromkeys(test_cases))
+        log.debug("Scope config reloaded")
 
         with self.scope_file.edit() as scope:
             scope['scope'] = scope_config['scope']

--- a/runnerd
+++ b/runnerd
@@ -27,10 +27,12 @@ import os
 import sys
 import time
 
+log_format='%(asctime)s %(levelname)-8s %(message)s'
+
 logging.basicConfig(
     filename="runnerd.log",
     level=logging.ERROR,
-    format='%(asctime)s %(levelname)-8s %(message)s',
+    format=log_format,
     datefmt='%Y-%m-%d %H:%M:%S')
 log = logging.getLogger("runnerd")
 
@@ -123,6 +125,7 @@ class DutsManager:
     base_dut_config_path = "configs/base_dut_config.yml"
 
     def __init__(self, duts_config_file):
+        self.lock = Lock()
         self.duts_config = None
         self.duts_config_file = duts_config_file
         self.base_dut_config = ConfigFile(self.base_dut_config_path).load()
@@ -130,21 +133,31 @@ class DutsManager:
         self.duts = {}
 
     def collect_duts(self):
-        if not self.duts_config_file.need_reload():
-            return
+        with self.lock:
+            if not self.duts_config_file.need_reload():
+                return
 
-        self.duts_config = self.duts_config_file.load()
-        host_list = [dut["host"] for dut in self.duts_config['duts']]
-        for host in self.duts.copy():
-            # remove duts deleted from duts_config_file
-            if host not in host_list:
-                del self.duts[host]
-        for config in self.duts_config['duts']:
-            host = config["host"]
-            add_dut = host not in self.duts
-            self.duts[host] = Dut({**self.base_dut_config, **config})
-            if add_dut:
-                self.mark_free(self.duts[host])
+            self.duts_config = self.duts_config_file.load()
+            configured_duts = self.duts_config.get('duts', [])
+            if configured_duts is None:
+                log.warning("Incorrect DUTs config!")
+                return
+            host_list = [dut["host"] for dut in self.duts_config["duts"]]
+            for host in self.duts.copy():
+                # remove duts deleted from duts_config_file
+                if host not in host_list:
+                    log.debug(f"Removing DUT {host} from scope")
+                    del self.duts[host]
+            if host_list:
+                for config in self.duts_config['duts']:
+                    host = config["host"]
+                    add_dut = host not in self.duts
+                    self.duts[host] = Dut({**self.base_dut_config, **config})
+                    if add_dut:
+                        log.debug(f"Adding DUT {host} to scope")
+                        self.mark_free(self.duts[host])
+            else:
+                log.warning("DUT list is empty!")
 
     def get_free_dut(self):
         dut = None
@@ -275,6 +288,7 @@ class MasterRunner:
 
     def run(self):
         def test_run_complete(dut, test_event):
+            self.duts_manager.collect_duts()
             self.duts_manager.mark_free(dut)
             test_event['end-timestamp'] = time.time()
             self.test_manager.mark_complete(test_event)
@@ -282,11 +296,13 @@ class MasterRunner:
 
         while True:
             self.duts_manager.collect_duts()
+            if not self.duts_manager.duts:
+                continue
             log.debug("Looking for free DUT... ")
             try:
                 dut = self.duts_manager.get_free_dut()
             except LookupError:
-                log.debug("No available DUTs found!")
+                log.warning("No available DUTs found!")
                 continue
             log.debug(f"Found DUT {dut.host}")
             log.debug("Looking for next test... ")
@@ -368,6 +384,10 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     log.setLevel((logging.INFO, logging.DEBUG)[args.debug])
+    if args.no_daemon:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(log_format))
+        log.addHandler(handler)
 
     if not os.path.isdir("meta"):
         print("Scope is not initialized in this directory!")

--- a/runnerd
+++ b/runnerd
@@ -125,7 +125,7 @@ class DutsManager:
     base_dut_config_path = "configs/base_dut_config.yml"
 
     def __init__(self, duts_config_file):
-        self.lock = Lock()
+        self.dut_dict_lock = Lock()
         self.duts_config = None
         self.duts_config_file = duts_config_file
         self.base_dut_config = ConfigFile(self.base_dut_config_path).load()
@@ -133,15 +133,20 @@ class DutsManager:
         self.duts = {}
 
     def collect_duts(self):
-        with self.lock:
-            while True:
-                try:
-                    if not self.duts_config_file.need_reload():
-                        return
-                    else:
-                        break
-                except FileNotFoundError:
-                    pass
+        start_time = time.time()
+        while True:
+            try:
+                if not self.duts_config_file.need_reload():
+                    return
+                else:
+                    break
+            except FileNotFoundError:
+                if time.time() - start_time > 5:
+                    log.warning("DUT configuration file not found!")
+                    start_time = time.time()
+                time.sleep(0.5)
+
+        with self.dut_dict_lock:
             log.info("Reloading DUTs config...")
             self.duts_config = self.duts_config_file.load()
             configured_duts = self.duts_config.get('duts', [])
@@ -166,21 +171,16 @@ class DutsManager:
                 log.warning("DUT list is empty!")
 
     def get_free_dut(self):
-        dut = None
-        while self.duts_queue.qsize():
-            free_dut = self.duts_queue.get()
-            if free_dut.host in self.duts:
-                dut = free_dut
-                break
-        if not dut:
-            raise LookupError()
-        return dut
+        free_dut = self.duts_queue.get()
+        if free_dut.host in self.duts:
+            return free_dut
 
     def mark_free(self, dut):
-        # DUTs can be removed from list or updated during test execution
-        # do not re-queue removed DUT or queue DUT by IP to get current DUT entry
-        if dut.host in self.duts:
-            self.duts_queue.put(self.duts[dut.host])
+        with self.dut_dict_lock:
+            # DUTs can be removed from list or updated during test execution
+            # do not re-queue removed DUT or queue DUT by IP to get current DUT entry
+            if dut.host in self.duts:
+                self.duts_queue.put(self.duts[dut.host])
 
 
 class TestManager:
@@ -294,9 +294,6 @@ class MasterRunner:
 
     def run(self):
         def test_run_complete(dut, test_event):
-            # Sometimes mark_free is quicker than reaching collect_duts in the loop below what
-            # results in queuing next test on removed DUT. collect_duts here prevents that.
-            self.duts_manager.collect_duts()
             self.duts_manager.mark_free(dut)
             test_event['end-timestamp'] = time.time()
             self.test_manager.mark_complete(test_event)

--- a/runnerd
+++ b/runnerd
@@ -333,23 +333,25 @@ class MasterRunner:
             self.results_collector.collect()
 
         while True:
-            self.duts_manager.collect_duts()
-            if not self.duts_manager.duts_queue.qsize():
-                continue
-            log.debug("Looking for a free DUT...")
-            try:
-                dut = self.duts_manager.get_free_dut()
-            except Empty:
-                log.debug("No free DUTs at the moment! Waiting...")
-                continue
-            log.debug(f"Found DUT {dut.host}")
             log.debug("Looking for the next test...")
             test_event = self.test_manager.get_next_test()
             log.debug(f"Found test {test_event}")
-            test_event['host'] = dut.host
-            test_event['start-timestamp'] = time.time()
-            self.test_manager.mark_started(test_event)
-            dut.run_test(test_event, test_run_complete)
+            while True:
+                self.duts_manager.collect_duts()
+                if not self.duts_manager.duts_queue.qsize():
+                    continue
+                log.debug("Looking for a free DUT...")
+                try:
+                    dut = self.duts_manager.get_free_dut()
+                except Empty:
+                    log.debug("No free DUTs at the moment! Waiting...")
+                    continue
+                log.debug(f"Found DUT {dut.host}")
+                test_event['host'] = dut.host
+                test_event['start-timestamp'] = time.time()
+                self.test_manager.mark_started(test_event)
+                dut.run_test(test_event, test_run_complete)
+                break
 
 
 class ScopeParser:

--- a/runnerd
+++ b/runnerd
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 #
 # Copyright(c) 2023 Intel Corporation
+# Copyright(c) 2024 Huawei Technologies
 # Copyright(c) 2026 Unvertical
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -26,7 +27,6 @@ import os
 import sys
 import time
 
-
 logging.basicConfig(
     filename="runnerd.log",
     level=logging.ERROR,
@@ -40,6 +40,7 @@ scriptdir = os.path.dirname(__file__)
 class EventHandler(FileSystemEventHandler):
     def __init__(self, callback):
         self.callback = callback
+
     def on_modified(self, event):
         self.callback()
 
@@ -96,7 +97,7 @@ class Dut:
         def run_in_thread(self, test_event, on_complete):
             self.config['meta'] = {
                 **test_event,
-                'test-case' : {**test_event['test-case']}
+                'test-case': {**test_event['test-case']}
             }
             tmp_conf_file = NamedTemporaryFile(prefix="dut_config_", suffix=".yml")
             ConfigFile(tmp_conf_file.name).save(self.config)
@@ -105,9 +106,9 @@ class Dut:
             test_case = test_event['test-case']
             log.info(f"Start {test_case} @ {self.host}")
             runner = PytestRunner(
-                test_dir = test_case['dir'],
-                log_dir = self.log_path,
-                stdout_path = self.stdout_path
+                test_dir=test_case['dir'],
+                log_dir=self.log_path,
+                stdout_path=self.stdout_path
             )
             runner.run(tmp_conf_file.name, test_case)
             log.info(f"Complete {test_case} @ {self.host}")
@@ -189,7 +190,7 @@ class TestManager:
     def __load_progress(self):
         self.test_events_complete.clear()
         with self.progress_file.edit() as progress:
-            if not 'test-events' in progress:
+            if 'test-events' not in progress:
                 return
             progress['test-events'] = list(filter(
                 lambda entry: entry['status'] == "complete",
@@ -284,6 +285,7 @@ class MasterRunner:
             test_event['end-timestamp'] = time.time()
             self.test_manager.mark_complete(test_event)
             self.results_collector.collect()
+
         while True:
             self.duts_manager.collect_duts()
             log.debug("Looking for free DUT... ")
@@ -302,6 +304,7 @@ class ScopeParser:
     scope_config_path = "configs/scope_config.yml"
 
     def __init__(self):
+        self.observer = None
         self.scope_config_file = ConfigFile(self.scope_config_path)
         self.scope_file = StatusFile("meta/scope.json")
 
@@ -347,6 +350,7 @@ class ScopeParser:
     def stop(self):
         self.observer.join()
 
+
 def daemonize(enabled):
     if enabled:
         print("Starting daemon")
@@ -355,6 +359,7 @@ def daemonize(enabled):
     else:
         print("Starting in non-daemon mode")
         return contextlib.suppress()
+
 
 if __name__ == '__main__':
     setproctitle('runnerd')

--- a/runnerd
+++ b/runnerd
@@ -122,38 +122,51 @@ class DutsManager:
     base_dut_config_path = "configs/base_dut_config.yml"
 
     def __init__(self, duts_config_file):
+        self.duts_config = None
         self.duts_config_file = duts_config_file
         self.base_dut_config = ConfigFile(self.base_dut_config_path).load()
         self.duts_queue = Queue()
-        self.duts = []
+        self.duts = {}
 
     def collect_duts(self):
         if not self.duts_config_file.need_reload():
             return
 
         self.duts_config = self.duts_config_file.load()
-        self.duts = []
+        host_list = [dut["host"] for dut in self.duts_config['duts']]
+        for host in self.duts.copy():
+            # remove duts deleted from duts_config_file
+            if host not in host_list:
+                del self.duts[host]
         for config in self.duts_config['duts']:
-            dut = Dut({**self.base_dut_config, **config})
-            self.duts.append(dut)
-            self.duts_queue.put(dut)
+            host = config["host"]
+            if host in self.duts:
+                # update config for existing dut
+                self.duts[host].config = {**self.base_dut_config, **config}
+            else:
+                # add dut
+                dut = Dut({**self.base_dut_config, **config})
+                self.duts[config["host"]] = dut
+                self.mark_free(dut)
 
     def get_free_dut(self, dut_filter=None):
         filtered_duts = []
-        found = False
+        dut = None
         for _ in self.duts:
-            dut = self.duts_queue.get()
-            if not dut_filter or dut_filter(dut):
-                found = True
+            free_dut = self.duts_queue.get()
+            if not dut_filter or dut_filter(free_dut):
+                dut = free_dut
                 break
-            filtered_duts.append(dut)
-        map(self.duts_queue.put, filtered_duts)
-        if not found:
+            if free_dut.host in self.duts:
+                filtered_duts.append(free_dut)
+        map(self.mark_free, filtered_duts)
+        if not dut:
             raise Exception("No DUT matching to filter!")
         return dut
 
     def mark_free(self, dut):
-        self.duts_queue.put(dut)
+        if dut.host in self.duts:
+            self.duts_queue.put(dut)
 
 
 class TestManager:

--- a/runnerd
+++ b/runnerd
@@ -5,11 +5,13 @@
 # Copyright(c) 2026 Unvertical
 # SPDX-License-Identifier: BSD-3-Clause
 #
+import signal
+import threading
 
 from common import ConfigFile, JournalFile, StatusFile, TestCase, TestEvent, JournalParser
 
 from pathlib import Path
-from queue import Queue
+from queue import Queue, Empty
 from setproctitle import setproctitle
 from subprocess import Popen, PIPE
 from tempfile import NamedTemporaryFile
@@ -37,6 +39,9 @@ logging.basicConfig(
 log = logging.getLogger("runnerd")
 
 scriptdir = os.path.dirname(__file__)
+
+child_pids = []
+pid_lock = Lock()
 
 
 class EventHandler(FileSystemEventHandler):
@@ -68,8 +73,12 @@ class PytestRunner:
         cmd += f"\"{test_case}\""
 
         out = open(self.stdout_path, "w") if self.stdout_path else PIPE
-        process = Popen(cmd, shell=True, stdout=out, stderr=out)
+        with pid_lock:
+            process = Popen(cmd, shell=True, stdout=out, stderr=out)
+            child_pids.append(process.pid)
         process.wait()
+        with pid_lock:
+            child_pids.remove(process.pid)
         if self.stdout_path:
             out.close()
 
@@ -178,9 +187,12 @@ class DutsManager:
                         log.debug(f"DUT {host} is already in use - skip adding to queue")
             log.debug("DUTs config reloaded")
 
-    def get_free_dut(self):
-        while True:
-            dut = self.duts_queue.get()
+    def get_free_dut(self, working: Event):
+        while working.is_set():
+            try:
+                dut = self.duts_queue.get(block=True, timeout=0.5)
+            except Empty:
+                continue
             with self.duts_lock:
                 if dut.host in self.duts:
                     self.duts_in_use.add(dut.host)
@@ -323,6 +335,7 @@ class MasterRunner:
         self.test_manager = TestManager()
         self.results_collector = ResultsCollector()
         self.results_collector.collect()
+        self.working = threading.Event()
 
     def run(self):
         def test_run_complete(dut, test_event):
@@ -332,24 +345,32 @@ class MasterRunner:
             self.results_collector.collect()
 
         def collect_duts():
-            while True:
+            while self.working.is_set():
                 self.duts_manager.collect_duts()
                 time.sleep(0.5)
 
         collector_thread = Thread(target=collect_duts)
+
+        self.working.set()
+
         collector_thread.start()
 
-        while True:
+        while self.working.is_set():
             log.debug("Looking for the next test...")
             test_event = self.test_manager.get_next_test()
             log.debug(f"Found test {test_event}")
             log.debug("Looking for a free DUT...")
-            dut = self.duts_manager.get_free_dut()
+            dut = self.duts_manager.get_free_dut(self.working)
+            if dut is None:
+                # when execution is interrupted
+                break
             log.debug(f"Found DUT {dut.host}")
             test_event['host'] = dut.host
             test_event['start-timestamp'] = time.time()
             self.test_manager.mark_started(test_event)
             dut.run_test(test_event, test_run_complete)
+
+        collector_thread.join()
 
 
 class ScopeParser:
@@ -404,12 +425,20 @@ class ScopeParser:
         self.observer.join()
 
 
-def daemonize(enabled):
+def daemonize(enabled, signal_handler):
     if enabled:
         print("Starting daemon")
         logger_files = [handler.stream.fileno() for handler in logging.root.handlers]
-        return daemon.DaemonContext(working_directory=os.getcwd(), files_preserve=logger_files)
+        signal_map = {
+            signal.SIGINT: signal_handler,
+            signal.SIGTERM: signal_handler,
+        }
+        return daemon.DaemonContext(
+            working_directory=os.getcwd(), files_preserve=logger_files, signal_map=signal_map,
+        )
     else:
+        signal.signal(signal.SIGINT, signal_handler)
+        signal.signal(signal.SIGTERM, signal_handler)
         print("Starting in non-daemon mode")
         return contextlib.suppress()
 
@@ -435,12 +464,21 @@ if __name__ == '__main__':
     try:
         lock = filelock.FileLock("meta/daemon.lock").acquire(timeout=0.01)
     except filelock.Timeout:
-        print("Another instance of 'runnerd' demon is active!")
+        print("Another instance of 'runnerd' daemon is active!")
         exit(1)
 
     print("Preparing scope")
     scope_parser = ScopeParser()
     scope_parser.start()
-    with daemonize(not args.no_daemon):
-        runner = MasterRunner()
+
+    runner = MasterRunner()
+
+    def signal_handler(signum, frame):
+        log.debug(f"Signal {signum} - terminate execution")
+        runner.working.clear()
+        with pid_lock:
+            for pid in child_pids:
+                os.kill(pid, signal.SIGTERM)
+
+    with daemonize(enabled=not args.no_daemon, signal_handler=signal_handler):
         runner.run()

--- a/runnerd
+++ b/runnerd
@@ -332,12 +332,19 @@ class MasterRunner:
             self.test_manager.mark_complete(test_event)
             self.results_collector.collect()
 
+        def collect_duts():
+            while True:
+                self.duts_manager.collect_duts()
+                time.sleep(0.5)
+
+        collector_thread = Thread(target=collect_duts)
+        collector_thread.start()
+
         while True:
             log.debug("Looking for the next test...")
             test_event = self.test_manager.get_next_test()
             log.debug(f"Found test {test_event}")
             while True:
-                self.duts_manager.collect_duts()
                 if not self.duts_manager.duts_queue.qsize():
                     continue
                 log.debug("Looking for a free DUT...")

--- a/runnerd
+++ b/runnerd
@@ -9,7 +9,7 @@
 from common import ConfigFile, JournalFile, StatusFile, TestCase, TestEvent, JournalParser
 
 from pathlib import Path
-from queue import Queue, Empty
+from queue import Queue
 from setproctitle import setproctitle
 from subprocess import Popen, PIPE
 from tempfile import NamedTemporaryFile
@@ -27,7 +27,7 @@ import os
 import sys
 import time
 
-log_format='%(asctime)s %(levelname)-8s %(message)s'
+log_format = '%(asctime)s %(levelname)-8s %(message)s'
 
 logging.basicConfig(
     filename="runnerd.log",
@@ -179,10 +179,9 @@ class DutsManager:
             log.debug("DUTs config reloaded")
 
     def get_free_dut(self):
-        with self.duts_lock:
-            while True:
-                # raise Empty if queue is empty
-                dut = self.duts_queue.get(block=False)
+        while True:
+            dut = self.duts_queue.get()
+            with self.duts_lock:
                 if dut.host in self.duts:
                     self.duts_in_use.add(dut.host)
                     return dut
@@ -210,10 +209,10 @@ class DutQueue(Queue):
                 super().put(dut, block, timeout)
 
     def get(self, block=True, timeout=None) -> Dut:
+        dut = super().get(block, timeout)
         with self.set_lock:
-            dut = super().get(block, timeout)
             self.dut_set.remove(dut.host)
-            return dut
+        return dut
 
 
 class TestManager:
@@ -344,21 +343,13 @@ class MasterRunner:
             log.debug("Looking for the next test...")
             test_event = self.test_manager.get_next_test()
             log.debug(f"Found test {test_event}")
-            while True:
-                if not self.duts_manager.duts_queue.qsize():
-                    continue
-                log.debug("Looking for a free DUT...")
-                try:
-                    dut = self.duts_manager.get_free_dut()
-                except Empty:
-                    log.debug("No free DUTs at the moment! Waiting...")
-                    continue
-                log.debug(f"Found DUT {dut.host}")
-                test_event['host'] = dut.host
-                test_event['start-timestamp'] = time.time()
-                self.test_manager.mark_started(test_event)
-                dut.run_test(test_event, test_run_complete)
-                break
+            log.debug("Looking for a free DUT...")
+            dut = self.duts_manager.get_free_dut()
+            log.debug(f"Found DUT {dut.host}")
+            test_event['host'] = dut.host
+            test_event['start-timestamp'] = time.time()
+            self.test_manager.mark_started(test_event)
+            dut.run_test(test_event, test_run_complete)
 
 
 class ScopeParser:


### PR DESCRIPTION
On editing duts_config replace configured duts
instead of adding all duts from modified config.
This allows for both adding and removing duts.
Current behavior led to duplicates if config contained
old duts in addition to new ones.